### PR TITLE
Adjust analyzedInstructions type in RecipeInformation

### DIFF
--- a/typescript/models/RecipeInformation.ts
+++ b/typescript/models/RecipeInformation.ts
@@ -13,6 +13,7 @@
 import { RecipeInformationExtendedIngredientsInner } from '../models/RecipeInformationExtendedIngredientsInner';
 import { RecipeInformationWinePairing } from '../models/RecipeInformationWinePairing';
 import { TasteInformation } from '../models/TasteInformation';
+import { AnalyzeRecipeInstructions200ResponseParsedInstructionsInner } from "../models/AnalyzeRecipeInstructions200ResponseParsedInstructionsInner";
 import { HttpFile } from '../http/http';
 
 /**
@@ -35,7 +36,7 @@ export class RecipeInformation {
     'healthScore': number;
     'spoonacularScore': number;
     'pricePerServing': number;
-    'analyzedInstructions': Array<any>;
+    'analyzedInstructions': Array<AnalyzeRecipeInstructions200ResponseParsedInstructionsInner>;
     'cheap': boolean;
     'creditsText': string;
     'cuisines': Array<string>;


### PR DESCRIPTION
Replaced `Array<any>` with `Array<AnalyzeRecipeInstructions200ResponseParsedInstructionsInner>`.

as I can see, analyzedInstructions part in the response looks similar to the AnalyzeRecipeInstructions200ResponseParsedInstructionsInner class:

```
...
"analyzedInstructions": [
        {
            "name": "",
            "steps": [...],
        },
],
...
```

```
class AnalyzeRecipeInstructions200ResponseParsedInstructionsInner {
  "name": string;
  "steps"?: Set<AnalyzeRecipeInstructions200ResponseParsedInstructionsInnerStepsInner>;
  ...
}
```